### PR TITLE
Feat: Read directory

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "github.copilot.enable": {
+    "*": false,
+    "plaintext": false,
+    "markdown": true,
+    "scminput": false
+  }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
+use mover::Mover;
 use reader::Reader;
 use std::env;
 
+mod mover;
 mod reader;
 
 fn main() {
@@ -10,7 +12,5 @@ fn main() {
         args[0].split("/").last().unwrap()
     ));
 
-    let reader = Reader::new(dir);
-
-    reader.read_folder();
+    let mover = Mover::new(Reader::new(dir).read_folder());
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,16 @@
+use reader::Reader;
 use std::env;
+
+mod reader;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
+    let dir = args.get(1).expect(&format!(
+        "Usage: {} <directory>",
+        args[0].split("/").last().unwrap()
+    ));
 
-    dbg!(args);
+    let reader = Reader::new(dir);
+
+    reader.read_folder();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,14 @@ fn main() {
         "Usage: {} <directory>",
         args[0].split("/").last().unwrap()
     ));
+    let is_dry_run = true;
 
     let mover = Mover::new(Reader::new(dir).read_folder());
+
+    let changes = mover.generate_change_log().join("\n");
+    println!("{}", changes);
+
+    if is_dry_run {
+        return;
+    }
 }

--- a/src/mover/mod.rs
+++ b/src/mover/mod.rs
@@ -1,0 +1,3 @@
+pub mod mover;
+
+pub use mover::Mover;

--- a/src/mover/mover.rs
+++ b/src/mover/mover.rs
@@ -1,0 +1,21 @@
+use crate::reader::file_entry::FileEntry;
+
+pub struct Mover {
+    files_to_move: Vec<FileEntry>,
+}
+
+impl Mover {
+    pub fn new(entries: Vec<FileEntry>) -> Self {
+        Mover {
+            files_to_move: entries,
+        }
+    }
+
+    pub fn generate_change_log() {
+        todo!();
+    }
+
+    pub fn reverse_changes() {
+        todo!()
+    }
+}

--- a/src/mover/mover.rs
+++ b/src/mover/mover.rs
@@ -11,11 +11,24 @@ impl Mover {
         }
     }
 
-    pub fn generate_change_log() {
-        todo!();
+    pub fn generate_change_log(&self) -> Vec<String> {
+        let mut result: Vec<String> = vec![];
+
+        for entity in &self.files_to_move {
+            let file_name = entity.get_file_name();
+            result.push(format!(
+                "{}/{} => {}",
+                entity.get_current_path(),
+                file_name,
+                entity.get_new_path(),
+            ));
+        }
+
+        result
     }
 
-    pub fn reverse_changes() {
+    #[allow(dead_code)]
+    pub fn reverse_changes(&self) {
         todo!()
     }
 }

--- a/src/reader/file_entry.rs
+++ b/src/reader/file_entry.rs
@@ -47,6 +47,7 @@ impl FileEntry {
         match self.extension.as_str() {
             "jpg" | "png" => "Images".to_string(),
             "docx" | "pdf" => "Documents".to_string(),
+            "ts" | "js" => "Trash".to_string(),
             _ => "Misc".to_string(),
         }
     }

--- a/src/reader/file_entry.rs
+++ b/src/reader/file_entry.rs
@@ -1,0 +1,57 @@
+use std::fmt::{Debug, Display, Formatter, Result};
+use std::path::PathBuf;
+
+pub struct FileEntry<'a> {
+    path: &'a PathBuf,
+    extension: &'a str,
+}
+
+pub enum FileType {
+    File,
+    Dir,
+    SymLink,
+    Unknown,
+}
+
+impl<'a> FileEntry<'a> {
+    pub fn new(path: &'a PathBuf, extension: &'a str) -> Self {
+        FileEntry { path, extension }
+    }
+
+    pub fn get_category(&self) -> &str {
+        match self.extension {
+            "jpg" | "png" => "Images",
+            "docx" | "pdf" => "Documents",
+            _ => "Misc",
+        }
+    }
+}
+
+impl<'a> Debug for FileEntry<'a> {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        write!(
+            f,
+            "FileEntry {{ path: {:?}, extension: {:?}, category: {:?} }}",
+            self.path,
+            self.extension,
+            self.get_category(),
+        )
+    }
+}
+
+impl FileType {
+    fn message(&self) -> &str {
+        match self {
+            Self::File => "File",
+            Self::Dir => "Directory",
+            Self::SymLink => "SymLink",
+            Self::Unknown => "Unknown",
+        }
+    }
+}
+
+impl Display for FileType {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        write!(f, "{}", self.message())
+    }
+}

--- a/src/reader/file_entry.rs
+++ b/src/reader/file_entry.rs
@@ -6,7 +6,7 @@ pub struct FileEntry {
     pub file_type: FileType,
     pub path: PathBuf,
     pub extension: String,
-    metadata: Metadata,
+    _metadata: Metadata,
 }
 
 #[derive(PartialEq)]
@@ -39,17 +39,32 @@ impl FileEntry {
             file_type,
             path,
             extension,
-            metadata,
+            _metadata: metadata,
         }
     }
 
-    pub fn get_category(&self) -> String {
+    pub fn get_category(&self) -> &str {
         match self.extension.as_str() {
-            "jpg" | "png" => "Images".to_string(),
-            "docx" | "pdf" => "Documents".to_string(),
-            "ts" | "js" => "Trash".to_string(),
-            _ => "Misc".to_string(),
+            "jpg" | "png" => "Images",
+            "docx" | "pdf" => "Documents",
+            "ts" | "js" => "Trash",
+            _ => "Misc",
         }
+    }
+
+    pub fn get_file_name(&self) -> String {
+        let file_name_os_str = self.path.file_name().unwrap();
+        let file_name_str = file_name_os_str.to_str().unwrap();
+        let file_name_owned = String::from(file_name_str);
+        file_name_owned.split('/').last().unwrap().to_string()
+    }
+
+    pub fn get_new_path(&self) -> String {
+        format!("{}/{}", self.get_category(), self.get_file_name())
+    }
+
+    pub fn get_current_path(&self) -> String {
+        self.path.parent().unwrap().to_str().unwrap().to_owned()
     }
 }
 

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -1,0 +1,4 @@
+pub mod file_entry;
+pub mod reader;
+
+pub use reader::Reader;

--- a/src/reader/reader.rs
+++ b/src/reader/reader.rs
@@ -1,5 +1,5 @@
 use super::file_entry::{FileEntry, FileType as FT};
-use std::fs;
+use std::fs::{self, File};
 use std::path::Path;
 
 pub struct Reader<'a> {
@@ -11,16 +11,19 @@ impl<'a> Reader<'a> {
         Reader { base_path }
     }
 
-    pub fn read_folder(&self) {
+    pub fn read_folder(&self) -> Vec<FileEntry> {
         let path = Path::new(self.base_path);
         let files = fs::read_dir(path).expect("Failed to read directory");
+        let mut file_entries: Vec<FileEntry> = vec![];
 
         for file in files {
             let f = file.unwrap();
             let file_entry = FileEntry::new(&f);
             if file_entry.file_type == FT::File {
-                dbg!(file_entry);
+                file_entries.push(file_entry);
             }
         }
+
+        file_entries
     }
 }

--- a/src/reader/reader.rs
+++ b/src/reader/reader.rs
@@ -1,0 +1,49 @@
+use super::file_entry::{FileEntry, FileType as FT};
+use std::fs;
+use std::fs::DirEntry;
+use std::io::Error as IOError;
+use std::path::{Path, PathBuf};
+
+pub struct Reader<'a> {
+    base_path: &'a str,
+}
+
+impl<'a> Reader<'a> {
+    pub fn new(base_path: &'a str) -> Self {
+        Reader { base_path }
+    }
+
+    pub fn read_folder(&self) {
+        let path = Path::new(self.base_path);
+        let files = fs::read_dir(path).expect("Failed to read directory");
+
+        for file in files {
+            let (path, file_type) = Self::get_file_details(file);
+            if file_type == FT::File.to_string() {
+                let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+                let file_entry = FileEntry::new(&path, ext);
+                dbg!(file_entry);
+            }
+        }
+    }
+
+    fn get_file_details(file: Result<DirEntry, IOError>) -> (PathBuf, String) {
+        if file.is_err() {
+            panic!("Could not read file")
+        }
+        let entry = file.ok().unwrap();
+        let path = entry.path();
+        let file_type = entry
+            .file_type()
+            .map(|ft| match ft {
+                ft if ft.is_dir() => FT::Dir,
+                ft if ft.is_file() => FT::File,
+                ft if ft.is_symlink() => FT::SymLink,
+                _ => FT::Unknown,
+            })
+            .unwrap_or(FT::Unknown)
+            .to_string();
+
+        (path, file_type)
+    }
+}

--- a/src/reader/reader.rs
+++ b/src/reader/reader.rs
@@ -1,5 +1,5 @@
 use super::file_entry::{FileEntry, FileType as FT};
-use std::fs::{self, File};
+use std::fs;
 use std::path::Path;
 
 pub struct Reader<'a> {

--- a/src/reader/reader.rs
+++ b/src/reader/reader.rs
@@ -1,8 +1,6 @@
 use super::file_entry::{FileEntry, FileType as FT};
 use std::fs;
-use std::fs::DirEntry;
-use std::io::Error as IOError;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 pub struct Reader<'a> {
     base_path: &'a str,
@@ -18,32 +16,11 @@ impl<'a> Reader<'a> {
         let files = fs::read_dir(path).expect("Failed to read directory");
 
         for file in files {
-            let (path, file_type) = Self::get_file_details(file);
-            if file_type == FT::File.to_string() {
-                let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
-                let file_entry = FileEntry::new(&path, ext);
+            let f = file.unwrap();
+            let file_entry = FileEntry::new(&f);
+            if file_entry.file_type == FT::File {
                 dbg!(file_entry);
             }
         }
-    }
-
-    fn get_file_details(file: Result<DirEntry, IOError>) -> (PathBuf, String) {
-        if file.is_err() {
-            panic!("Could not read file")
-        }
-        let entry = file.ok().unwrap();
-        let path = entry.path();
-        let file_type = entry
-            .file_type()
-            .map(|ft| match ft {
-                ft if ft.is_dir() => FT::Dir,
-                ft if ft.is_file() => FT::File,
-                ft if ft.is_symlink() => FT::SymLink,
-                _ => FT::Unknown,
-            })
-            .unwrap_or(FT::Unknown)
-            .to_string();
-
-        (path, file_type)
     }
 }


### PR DESCRIPTION
## Changes Overview
This PR implements the core functionality for a file organization system in Rust. The system can scan directories and propose file movements based on file extensions.

### 🏗 New Components

1. Reader Module
    - Implements directory scanning functionality
    - FileEntry struct to represent files with metadata
    - File type categorization based on extensions
    - Mover Module
2. Handles file movement operations
    - Generates change logs for proposed file movements
    - Includes scaffolding for reversing changes
3. Main Program Updates
    - Added command-line argument handling
    - Implemented dry-run functionality
    - Integration of Reader and Mover components

### 📁 File Categories
Currently supports the following categories:
- Images (.jpg, .png)
- Documents (.docx, .pdf)
- Trash (.ts, .js) 😁 
- Misc (all other extensions)

### 🔄 Usage
`organize-rs <directory>`

### 📝 Notes
- Currently runs in dry-run mode by default
- Changes are only logged, not executed