### PR TITLE
Feat: Add mover functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/playground*

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -1,12 +1,14 @@
 use std::path::PathBuf;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct Config {
     pub exclude: Vec<String>,
     pub target_dir: PathBuf,
     config_file_path: Option<PathBuf>,
     pub is_dry_run: bool,
     pub is_stats_run: bool,
+    pub is_verbose: bool,
 }
 
 impl Config {
@@ -15,6 +17,7 @@ impl Config {
         let mut config_file_path = None;
         let mut is_dry_run = false;
         let mut is_stats_run = false;
+        let mut is_verbose = false;
 
         let mut iter = args.into_iter().skip(1);
         let target_dir = match iter.next() {
@@ -26,6 +29,7 @@ impl Config {
             match arg.as_str() {
                 "--dry-run" => is_dry_run = true,
                 "--stats" => is_stats_run = true,
+                "--verbose" => is_verbose = true,
                 "--exclude" => {
                     let patterns = iter
                         .next()
@@ -48,6 +52,7 @@ impl Config {
             config_file_path,
             is_dry_run,
             is_stats_run,
+            is_verbose,
         })
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use config::Config;
 use mover::Mover;
 use reader::Reader;
-use std::env;
+use std::{env, fs};
 
 mod config;
 mod mover;
@@ -11,12 +11,23 @@ fn main() {
     let args: Vec<String> = env::args().collect();
     let config = Config::new(args).expect("Failed to parse command line arguments");
 
+    let target_dir = config.clone().target_dir;
     let mover = Mover::new(Reader::new(config.target_dir, config.exclude).read_folder());
-
     let changes = mover.generate_change_log().join("\n");
-    println!("{}", changes);
 
     if config.is_dry_run {
         return;
+    }
+
+    if config.is_verbose {
+        println!("{}", changes);
+    }
+
+    if let Err(e) = mover.do_move_files() {
+        println!("Failed with error {}", e);
+    }
+
+    if let Err(e) = fs::write(target_dir.join("changelog.txt"), changes) {
+        println!("Failed to write changelog: {}", e);
     }
 }

--- a/src/mover/mover.rs
+++ b/src/mover/mover.rs
@@ -1,4 +1,5 @@
 use crate::reader::file_entry::FileEntry;
+use std::fs;
 
 pub struct Mover {
     files_to_move: Vec<FileEntry>,
@@ -17,14 +18,52 @@ impl Mover {
         for entry in &self.files_to_move {
             let file_name = entry.get_file_name();
             result.push(format!(
-                "{}/{} => {}",
-                entry.get_current_path(),
-                file_name,
-                entry.get_new_path(),
+                "{} => {}",
+                format!("{}/{}", entry.get_current_path(), file_name),
+                format!(
+                    "{}/{}/{}",
+                    entry.get_current_path(),
+                    entry.get_new_path(),
+                    file_name
+                ),
             ));
         }
 
         result
+    }
+
+    pub fn do_move_files(&self) -> Result<bool, String> {
+        for entry in &self.files_to_move {
+            let category = entry.get_new_path();
+            let file_name = entry.get_file_name();
+            let base_path = entry.get_current_path();
+            let new_path = format!("{}/{}", base_path, category);
+
+            // Create directory if it doesn't exist
+            if !fs::exists(&new_path)
+                .map_err(|e| format!("Mover: Error checking path existence: {}", e))?
+            {
+                fs::create_dir_all(&new_path).map_err(|e| {
+                    format!("Mover: Failed to create directory at {}: {}", new_path, e)
+                })?;
+            }
+
+            // Construct source and destination paths
+            let from = format!("{}/{}", base_path, file_name);
+            let to = format!("{}/{}", new_path, file_name);
+
+            // Try to rename (move) the file
+            if let Err(_) = fs::rename(&from, &to) {
+                // If rename fails, try copy and delete as fallback
+                fs::copy(&from, &to)
+                    .map_err(|e| format!("Mover: Error copying file to {}: {}", &to, e))?;
+
+                fs::remove_file(&from).map_err(|e| {
+                    format!("Mover: Error deleting original file at {}: {}", &from, e)
+                })?;
+            }
+        }
+        Ok(true)
     }
 
     #[allow(dead_code)]

--- a/src/mover/mover.rs
+++ b/src/mover/mover.rs
@@ -14,13 +14,13 @@ impl Mover {
     pub fn generate_change_log(&self) -> Vec<String> {
         let mut result: Vec<String> = vec![];
 
-        for entity in &self.files_to_move {
-            let file_name = entity.get_file_name();
+        for entry in &self.files_to_move {
+            let file_name = entry.get_file_name();
             result.push(format!(
                 "{}/{} => {}",
-                entity.get_current_path(),
+                entry.get_current_path(),
                 file_name,
-                entity.get_new_path(),
+                entry.get_new_path(),
             ));
         }
 

--- a/src/reader/file_entry.rs
+++ b/src/reader/file_entry.rs
@@ -45,9 +45,13 @@ impl FileEntry {
 
     pub fn get_category(&self) -> &str {
         match self.extension.as_str() {
-            "jpg" | "png" => "Images",
-            "docx" | "pdf" => "Documents",
-            "ts" | "js" => "Trash",
+            "jpg" | "png" | "gif" => "Images",
+            "docx" | "pdf" | "html" => "Documents",
+            "txt" | "md" => "Text",
+            "css" | "scss" => "Styles",
+            "ts" | "js" => "Code",
+            "woff" | "woff2" | "otf" => "Fonts",
+            "json" | "conf" | "yml" | "yaml" | "toml" => "Config",
             _ => "Misc",
         }
     }
@@ -60,7 +64,7 @@ impl FileEntry {
     }
 
     pub fn get_new_path(&self) -> String {
-        format!("{}/{}", self.get_category(), self.get_file_name())
+        format!("{}", self.get_category())
     }
 
     pub fn get_current_path(&self) -> String {

--- a/src/reader/reader.rs
+++ b/src/reader/reader.rs
@@ -2,6 +2,7 @@ use super::file_entry::{FileEntry, FileType as FT};
 use std::fs;
 use std::path::PathBuf;
 
+#[allow(dead_code)]
 pub struct Reader {
     target_dir: PathBuf,
     exclude: Vec<String>,


### PR DESCRIPTION
# Implement file organization functionality

## Changes
- Added file organization functionality to move files into appropriate directories based on their extensions
- Added new file categories and improved categorization logic
- Added verbose mode and changelog generation
- Improved error handling for file operations

### New Features
- Added `--verbose` flag to show detailed changes
- Files are now automatically moved to appropriate directories based on their extensions
- Generates a changelog.txt file with all file movements
- Added support for more file types and categories:
  - Images: jpg, png, gif
  - Documents: docx, pdf, html
  - Text: txt, md
  - Styles: css, scss
  - Code: ts, js
  - Fonts: woff, woff2, otf
  - Config: json, conf, yml, yaml, toml
  - Misc: all other types

### Technical Changes
- Added `is_verbose` field to Config struct
- Implemented `do_move_files()` method in Mover
- Improved file path handling and directory creation
- Added fallback mechanism for file moves (copy + delete if rename fails)
- Added playground directories to .gitignore